### PR TITLE
#7: CV PoC scaffolding (docs, fixtures, alternatives note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ result = render_data(template, context, handle_missing=MissingKeyHandling.DEFAUL
 result = render_data("{complex_object}", context)
 ```
 
+## CV resume PoC (preview)
+
+End-to-end demo (Word template + JSON5/YAML data + markdown validation report) is tracked in GitHub epic [#7](https://github.com/pkuppens/templify/issues/7). Documentation lives under [`docs/cv_poc/`](docs/cv_poc/); sample data under [`examples/cv_resume_poc/`](examples/cv_resume_poc/).
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/docs/cv_poc/alternatives-to-templify.md
+++ b/docs/cv_poc/alternatives-to-templify.md
@@ -1,0 +1,62 @@
+# Alternatives to Templify for “template + data → document”
+
+Epic: https://github.com/pkuppens/templify/issues/7 · Issue: https://github.com/pkuppens/templify/issues/9
+
+This note compares **templating stacks** for structured documents—not Word engine choice (`python-docx` vs `docxtpl` is a separate implementation detail for `.docx`).
+
+## Templify (this repo)
+
+**Relevant APIs:** `render_data`, `render_text`, `render_jinja2`, `MissingKeyHandling` in [`src/templify/core.py`](../../src/templify/core.py).
+
+| Strength | Notes |
+|----------|--------|
+| Recursive dict/list templates | `render_data` walks structures and replaces `{placeholders}` and Jinja/JMESPath segments in strings. |
+| Missing-key policy | `KEEP`, `DEFAULT`, `RAISE` shared across text/data/Jinja paths (behaviour differs slightly for Jinja vs plain placeholders). |
+| JMESPath in strings | Useful for summaries over arrays without custom code. |
+| Jinja2 bridge | `render_jinja2` wraps `Environment` with loaders, custom filters, undefined classes per policy. |
+
+**Gaps / caveats (re-validated against current tree):**
+
+| Area | Detail |
+|------|--------|
+| **CLI** | [`src/templify/cli.py`](../../src/templify/cli.py) exposes `render` / `validate` but does **not** implement them (stub). |
+| **DOCX** | No first-class `.docx` pipeline; CV PoC will add integration (python-docx / docxtpl / etc.) **alongside** templify for merge logic. |
+| **PDF** | `render_pdf` expects XML-ish structure after `render_data`, then only `<text>` tags become ReportLab `Paragraph`s—**narrow** layout model, not a general Word replacement. |
+| **“Single `render` router”** | [`docs/development/architecture.md`](../../docs/development/architecture.md) describes a unified `render()`; the **exported** API remains separate functions (`render_data`, `render_jinja2`, …). |
+
+## Jinja2-only
+
+Use **`jinja2.Environment`** directly: loaders, globals, filters, **StrictUndefined** / **undefined** choices, templates on disk.
+
+| vs Templify | |
+|-------------|--|
+| **Pros** | Mature ecosystem, IDE support, inheritance/includes, large community. |
+| **Cons** | No built-in **recursive `render_data`** over JSON payloads; you combine Jinja with custom glue. Templify adds that glue plus JMESPath-in-string patterns. |
+
+**When to prefer Jinja2-only:** mostly free-form text/HTML documents with file templates and no need for recursive JSON template trees.
+
+## Mako
+
+Fast, Python-centric. Heavier security/process story for untrusted templates. Less common for document pipelines than Jinja2 in Python—reasonable for code generation, not the default for CV PoC.
+
+## docxtpl
+
+**Role:** embed **Jinja2** inside Word documents—not an alternative to Templify’s *entire* model, but a **delivery** option when placeholders live in `.docx`. Often used as **Templify + docxtpl**: build context dict in Python (optionally via `render_data`-style preprocessing), then `docxtpl` renders the Word file.
+
+## PDF paths
+
+| Option | When |
+|--------|------|
+| Existing **`render_pdf`** | PoC spike for “same XML template → PDF” only; limited tag subset. |
+| HTML → PDF (weasyprint, etc.) | Not in repo today; add only if layout requirements justify new deps. |
+| Duplicate PDF from Word | Export from Word/LibreOffice manually—out of scope for automation in minimal PoC. |
+
+## “What’s new” (lightweight scan, 2024–2026)
+
+Template engines in Python are still dominated by **Jinja2**; **StrictUndefined** and environment config remain the main control levers. Niche “document merge” tools exist per vendor (Office, Google); nothing broadly replaces a small library + `python-docx` for on-prem CV generation without evaluating licence and format lock-in.
+
+## Recommendation for this CV PoC
+
+- **Keep Templify** for **data-side** templating (recursive structures, missing-key policy, optional JMESPath) and for **report generation** strings.
+- **Add** a dedicated **Word** integration (e.g. docxtpl or python-docx) for `.docx` output; treat it as **transport**, not a replacement for Templify’s `render_data`.
+- **Revisit** if the PoC only needs **flat** Jinja files + HTML—then Jinja2-only plus a static site generator could be simpler, but that is **not** the Word + JSON5/YAML epic scope.

--- a/docs/cv_poc/data_model.md
+++ b/docs/cv_poc/data_model.md
@@ -1,0 +1,42 @@
+# CV PoC — canonical data model (NL)
+
+This document defines the **logical** resume data used by the CV proof of concept. **YAML** and **JSON5** files must load to the same nested structure (see `examples/cv_resume_poc/data/`).
+
+Epic: https://github.com/pkuppens/templify/issues/7 · Issue: https://github.com/pkuppens/templify/issues/8
+
+## Versioning
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Document format version (e.g. `0.1`). Optional for early PoC; recommend setting once CLI validates. |
+
+## Personalia (`personalia`)
+
+Contact and identity block. Field names are **Dutch** to match typical CV conventions.
+
+| Field | Type | Optionality | Multiplicity |
+|-------|------|-------------|--------------|
+| `naam` | string | required | single |
+| `adres` | string | optional | single |
+| `telefoon` | list of string | optional | 0..n |
+| `email` | list of string | optional | 0..n |
+| `linkedin` | string (URI) | optional | single |
+
+Nested lists allow multiple phone numbers or emails without repeating field names.
+
+## Optional sections (future)
+
+The PoC may add `ervaring`, `opleiding`, etc. Add rows here when templates reference them.
+
+## Example shape (YAML)
+
+See `examples/cv_resume_poc/data/cv_minimal.yaml`.
+
+## Example shape (JSON5)
+
+See `examples/cv_resume_poc/data/cv_minimal.json5` (comments allowed; parsed object must match YAML).
+
+## Template vs data
+
+- **Data file**: this structure (JSON5 or YAML).
+- **Word template**: placeholders agreed with implementation (e.g. Jinja-style `{{ personalia.naam }}` or project-specific tokens). The mismatch report (issue #10) will compare **template keys** to **data paths**.

--- a/docs/cv_poc/validation.md
+++ b/docs/cv_poc/validation.md
@@ -1,0 +1,41 @@
+# CV PoC — validation runbook
+
+Epic: https://github.com/pkuppens/templify/issues/7 · Issue: https://github.com/pkuppens/templify/issues/14
+
+Use this checklist when the PoC entrypoint and report generator exist. Until then, steps marked *future* are placeholders.
+
+## Preconditions
+
+- [ ] Repository synced; optional CV dependencies installed per `README` / `pyproject` group.
+- [ ] Sample data: `examples/cv_resume_poc/data/cv_minimal.yaml` and `cv_minimal.json5`.
+
+## Run (future)
+
+1. Run the documented one-liner (e.g. `run_poc.py` or CLI) with:
+   - `--data` pointing to YAML **and** once to JSON5 (same logical content).
+   - A Word template path when available.
+2. Confirm exit code **0** for happy path.
+3. Open output `.docx` in Word or LibreOffice (no repair dialog).
+
+## Outputs to verify
+
+- [ ] **Filled document** matches expected placeholders for the sample.
+- [ ] **Markdown report** contains sections: Summary; Missing in data; Superfluous in data; Optional blocks; Multiplicity; Warnings.
+
+## Edge-case matrix
+
+| Scenario | Input | Expected report section / behaviour |
+|----------|-------|-------------------------------------|
+| All keys present | Full sample data + matching template | Summary counts zero missing; Optional blocks show “provided” where applicable |
+| Missing optional field | Data without `personalia.linkedin` | Missing or Optional (per design); not fatal if optional |
+| Missing required field | Data without `personalia.naam` | **Missing in data**; exit non-zero if `--strict` |
+| Empty list | `telefoon: []` | **Multiplicity** or Warnings; document policy |
+| Extra key in data | Unknown top-level key | **Superfluous in data** |
+| Duplicate placeholder in template | Same token twice | No crash; count in Summary if implemented |
+| UTF-8 Dutch | Names with **é**, **IJ**, etc. | Correct in `.docx` and report |
+| JSON5 comments | `cv_minimal.json5` with `//` comments | Parsed same as YAML; **Warnings** may note comments stripped post-parse |
+
+## Sign-off
+
+- [ ] Reviewer name / date
+- [ ] Notes

--- a/examples/cv_resume_poc/README.md
+++ b/examples/cv_resume_poc/README.md
@@ -1,0 +1,15 @@
+# CV resume PoC (synthetic fixtures)
+
+Epic: https://github.com/pkuppens/templify/issues/7
+
+This folder holds **minimal, synthetic** sample data for the Dutch CV proof of concept. Replace or extend with anonymized real templates from your environment when available.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `data/cv_minimal.yaml` | Same logical content as JSON5 (YAML) |
+| `data/cv_minimal.json5` | Same content with JSON5 comments and trailing comma |
+| `template/` | Word `.docx` template with placeholders (add under implementation issues) |
+
+Data files use UTF-8 and Dutch field names under `personalia`.

--- a/examples/cv_resume_poc/data/cv_minimal.json5
+++ b/examples/cv_resume_poc/data/cv_minimal.json5
@@ -1,0 +1,12 @@
+/* Minimal synthetic CV data (Dutch keys) — mirrors cv_minimal.yaml */
+{
+  schema_version: "0.1",
+  personalia: {
+    naam: "Jan de Vries",
+    adres: "1234 AB Utrecht",
+    // Optioneel: meerdere items
+    telefoon: ["+31 6 12345678"],
+    email: ["jan.devries@voorbeeld.nl"],
+    linkedin: "https://linkedin.com/in/example",
+  },
+}

--- a/examples/cv_resume_poc/data/cv_minimal.yaml
+++ b/examples/cv_resume_poc/data/cv_minimal.yaml
@@ -1,0 +1,12 @@
+# Minimal synthetic CV data (Dutch keys) — mirrors cv_minimal.json5
+schema_version: "0.1"
+
+personalia:
+  naam: "Jan de Vries"
+  adres: "1234 AB Utrecht"
+  # Optioneel: meerdere nummers
+  telefoon:
+    - "+31 6 12345678"
+  email:
+    - "jan.devries@voorbeeld.nl"
+  linkedin: "https://linkedin.com/in/example"

--- a/examples/cv_resume_poc/template/README.md
+++ b/examples/cv_resume_poc/template/README.md
@@ -1,0 +1,3 @@
+Place the **Word template** (`.docx`) here when available. Placeholders should align with `docs/cv_poc/data_model.md` and the sample files in `../data/`.
+
+Until a template is committed, PoC implementations may use a programmatically generated minimal `.docx` or a fixture added in the implementation issue.


### PR DESCRIPTION
Related to #7. Adds \docs/cv_poc/\ (data model, alternatives-to-templify, validation runbook), synthetic \examples/cv_resume_poc/data\ YAML + JSON5, README link. Child issues #8–#14 remain for full implementation.

**Note:** Pre-commit \mkdocs-build\ was skipped locally (minify plugin missing in hook env); verify CI / fix mkdocs deps if the build fails.